### PR TITLE
Create and link trip identifiers

### DIFF
--- a/controllers/tripController.js
+++ b/controllers/tripController.js
@@ -62,7 +62,11 @@ exports.confirmPickup = asyncHandler(async (req, res) => {
           vehicle_info: driverInfo?.vehicle_info || null,
         },
         confirmed_at: updatedTrip.actual_pickup_time,
-        confirmed_by: passengerInfo?.name || req.user.id
+        confirmed_by: passengerInfo?.name || req.user.id,
+        links: {
+          self: `/trip/${tripId}`,
+          dropoff: `/trip/${tripId}/dropoff`
+        }
       }
     });
   } catch (error) {

--- a/routes/indexRoutes.js
+++ b/routes/indexRoutes.js
@@ -30,6 +30,8 @@ router.use("/payments", paymentRoutes);
 router.use("/subscriptions", subscriptionRoutes);
 router.use("/schedules", scheduleRoutes);
 router.use("/trips", tripRoutes);
+// Alias singular form for clients using /trip
+router.use("/trip", tripRoutes);
 router.use("/passenger", passengerRoutes);
 router.use("/driver", driverRoutes);
 router.use("/admin", adminRoutes);


### PR DESCRIPTION
Add `/trip` route alias and include trip detail links in pickup confirmation response.

The user requested that upon passenger pickup confirmation, the response should include direct links to the trip details (`/trip/{tripId}`) and the dropoff endpoint (`/trip/{tripId}/dropoff`). This PR implements those links and adds a singular `/trip` alias to support the requested URL structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-20858545-b749-4eb6-8151-fc779838fe7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20858545-b749-4eb6-8151-fc779838fe7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

